### PR TITLE
[Android] Fix android apk name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 app-release.apk filter=lfs diff=lfs merge=lfs -text
+mlc-chat.apk filter=lfs diff=lfs merge=lfs -text

--- a/app-release.apk
+++ b/app-release.apk
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7b937c7be3b7e5f8164f0f1ef58c9e1df15fd0f08721fbf7fe16d058ef09c6e
-size 123551778


### PR DESCRIPTION
This PR fixes the android apk  name from `app-release.apk` to `mlc-chat.apk`.